### PR TITLE
fix issues with receipes and farmersdelight update 3.0.0

### DIFF
--- a/src/main/resources/data/trailandtales_delight/advancement/tat_delight.json
+++ b/src/main/resources/data/trailandtales_delight/advancement/tat_delight.json
@@ -2,7 +2,7 @@
   "display": {
     "background": "trailandtales_delight:textures/screen/advancement_background.png",
     "icon": {
-      "item": "trailandtales_delight:pottery_cooking_pot"
+      "id": "trailandtales_delight:pottery_cooking_pot"
     },
     "title": {
       "translate": "advancements.tat_delight.title"

--- a/src/main/resources/data/trailandtales_delight/loot_table/blocks/lantern_fruits.json
+++ b/src/main/resources/data/trailandtales_delight/loot_table/blocks/lantern_fruits.json
@@ -52,7 +52,7 @@
           "condition": "minecraft:block_state_property",
           "block": "trailandtales_delight:lantern_fruits",
           "properties": {
-            "ropelogged": false
+            "ropelogged": "false"
           }
         }
       ]

--- a/src/main/resources/data/trailandtales_delight/loot_table/blocks/pottery_cooking_pot.json
+++ b/src/main/resources/data/trailandtales_delight/loot_table/blocks/pottery_cooking_pot.json
@@ -2,6 +2,7 @@
   "type": "minecraft:block",
   "pools": [
     {
+      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "conditions": [
         {
@@ -11,20 +12,21 @@
       "entries": [
         {
           "type": "minecraft:item",
+          "name": "trailandtales_delight:pottery_cooking_pot",
           "functions": [
             {
-              "function": "minecraft:copy_name",
-              "source": "block_entity"
-            },
-            {
-              "function": "farmersdelight:copy_meal"
+              "function": "minecraft:copy_components",
+              "source": "block_entity",
+              "include": [
+                "minecraft:custom_name",
+                "farmersdelight:meal",
+                "farmersdelight:container"
+              ]
             }
-          ],
-          "name": "trailandtales_delight:pottery_cooking_pot"
+          ]
         }
-      ],
-      "rolls": 1.0
+      ]
     }
   ],
-  "random_sequence": "trailandtales_delight:block/pottery_cooking_pot"
+  "random_sequence": "trailandtales_delight:blocks/cooking_pot"
 }

--- a/src/main/resources/data/trailandtales_delight/recipe/cutting/cherry_petal_from_cherry_sapling.json
+++ b/src/main/resources/data/trailandtales_delight/recipe/cutting/cherry_petal_from_cherry_sapling.json
@@ -7,8 +7,10 @@
   ],
   "result": [
     {
-      "count": 4,
-      "id": "trailandtales_delight:cherry_petal"
+      "item": {
+        "count": 4,
+        "id": "trailandtales_delight:cherry_petal"
+      }
     },
     {
       "item": {


### PR DESCRIPTION
fixed followed issues

```
[12:07:31] [Worker-Main-3/ERROR]: Couldn't parse element minecraft:loot_table/trailandtales_delight:blocks/lantern_fruits - Failed to parse either. First: Not a string: false; Second: Not a JSON object: false missed input: {"ropelogged":false} 
[12:07:31] [Worker-Main-3/ERROR]: Couldn't parse element minecraft:loot_table/trailandtales_delight:blocks/pottery_cooking_pot - Failed to parse either. First: Unknown registry key in ResourceKey[minecraft:root / minecraft:loot_function_type]: farmersdelight:copy_meal; Second: Not a json array: {"function":"farmersdelight:copy_meal"} 
[12:07:32] [main/ERROR]: Parsing error loading recipe trailandtales_delight:cutting/cherry_petal_from_cherry_sapling com.google.gson.JsonParseException: No key item in MapLike[{"count":4,"id":"trailandtales_delight:cherry_petal"}] at knot/com.mojang.serialization.DataResult$Error.md696600$owo$lambda$addStackTraceToException$0$0(DataResult.java:565) ~[datafixerupper-8.0.16.jar:?] at knot/com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287) ~[datafixerupper-8.0.16.jar:?] at knot/net.minecraft.class_1863.method_20705(class_1863.java:62) ~[server-intermediary.jar:?] at knot/net.minecraft.class_1863.method_18788(class_1863.java:35) ~[server-intermediary.jar:?] at knot/net.minecraft.class_4080.method_18790(class_4080.java:13) ~[server-intermediary.jar:?] at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718) ~[?:?] at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?] at knot/net.minecraft.class_4014.method_18365(class_4014.java:69) ~[server-intermediary.jar:?] at knot/net.minecraft.class_156.method_43498(class_156.java:1024) [server-intermediary.jar:?] at knot/net.minecraft.class_156.method_43499(class_156.java:1012) [server-intermediary.jar:?] at knot/net.minecraft.server.Main.main(Main.java:182) [server-intermediary.jar:?] at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:506) [fabric-loader-0.17.2.jar:?] at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72) [fabric-loader-0.17.2.jar:?] at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.17.2.jar:?] at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.17.2.jar:?] at net.fabricmc.installer.ServerLauncher.main(ServerLauncher.java:69) [fabric.jar:1.1.0] 
[12:07:33] [main/ERROR]: Parsing error loading custom advancement trailandtales_delight:tat_delight: No key id in MapLike[{"item":"trailandtales_delight:pottery_cooking_pot"}
```